### PR TITLE
Disable debug_package to fix RHEL 9 build

### DIFF
--- a/slurm-spank-private-tmpdir.spec
+++ b/slurm-spank-private-tmpdir.spec
@@ -15,6 +15,8 @@ Requires: slurm
 Slurm SPANK plugin that uses file system namespaces to create private
 temporary directories for each job.
 
+%global debug_package %{nil}
+
 %prep
 %setup -q
 # Dummy file used to get a RPM dependency on libslurm.so


### PR DESCRIPTION
Otherwise build fails with the following error on CentOS / RHEL 9:

> error: Empty %files file /root/rpmbuild/BUILD/slurm-spank-private-tmpdir-0.0.2/debugsourcefiles.list
    Signature not supported. Hash algorithm SHA1 not available.
    Deprecated external dependency generator is used!
    Empty %files file /root/rpmbuild/BUILD/slurm-spank-private-tmpdir-0.0.2/debugsourcefiles.list